### PR TITLE
[Fix]管理者側注文履歴、日付順にソート

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,6 +1,6 @@
 class Admin::HomesController < ApplicationController
   def top
-    @orders = Order.page(params[:page])
+    @orders = Order.page(params[:page]).order(created_at: :desc)
 
   end
 end

--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -4,10 +4,10 @@ class Admin::OrderItemsController < ApplicationController
     order = order_item.order
     order_items = order.order_items
     order_item.update(order_item_params)
-    if  order_items.find_by(manufacture_status: 2)
-      order.update(order_status: 2)
-    elsif order_items.where(manufacture_status: 3).count == order_items.count
-      order.update(order_status: 3)
+    if  order_items.find_by(manufacture_status: "manufacturing")
+      order.update(order_status: "producting")
+    elsif order_items.where(manufacture_status: "manufactured").count == order_items.count
+      order.update(order_status: "shipping_preparation")
     end
     redirect_to admin_order_path(order_item.order_id)
   end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrdersController < ApplicationController
   def index
     @customer = Customer.find(params[:id])
-    @orders = @customer.orders.page(params[:page])
+    @orders = @customer.orders.page(params[:page]).order(created_at: :desc)
   end
   def show
     @order = Order.find(params[:id])
@@ -10,8 +10,9 @@ class Admin::OrdersController < ApplicationController
 
   def update
     order = Order.find(params[:id])
-     order.update(order_params)
-    if  order.order_status = 1
+
+    order.update(order_params)
+    if  order.order_status == "payment_comfirmation"
       order.order_items.update_all(manufacture_status: 1)
     end
     redirect_to admin_order_path(order)

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -13,7 +13,7 @@ class Admin::OrdersController < ApplicationController
 
     order.update(order_params)
     if  order.order_status == "payment_comfirmation"
-      order.order_items.update_all(manufacture_status: 1)
+      order.order_items.update_all(manufacture_status: "waiting_for_manufacture")
     end
     redirect_to admin_order_path(order)
   end


### PR DESCRIPTION
１　注文履歴一覧・会員ごとの注文履歴一覧
　　日付が新しい順に並ぶように設定
２　ステータス一部修正
　　記述誤りを修正